### PR TITLE
let's encrypt compatibility for dotfile blocking

### DIFF
--- a/security/wordpress_security.conf
+++ b/security/wordpress_security.conf
@@ -2,7 +2,9 @@
 location ~ ^/\.(well-known)/ { expires 0; }
 
 # Deny all attempts to access hidden files such as .htaccess, .htpasswd, .DS_Store (Mac).
-location ~ /\. { deny all; }
+# uses regex negative lookahead to allow use of letsencrypt webroot authentication
+# in the .wellknown directory
+location ~ /\.(?!well\-known) { deny  all; }
 
 # Prevent access to any files starting with a $ (usually temp files)
 location ~ ~$ { deny all; }


### PR DESCRIPTION
blocks all filenames beginning with `.` except `.well-known`